### PR TITLE
Inner join each query on the population table

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -89,7 +89,13 @@ class StudyDefinition:
         joins = []
         for column_name, (cols, sql) in self.covariates.items():
             table_queries.append(
-                (column_name, f"SELECT * INTO #{column_name} FROM ({sql}) t")
+                (
+                    column_name,
+                    f"""
+                    SELECT t.* INTO #{column_name} FROM ({sql}) t
+                    INNER JOIN #population ON #population.patient_id = t.patient_id
+                    """,
+                )
             )
             joins.append(
                 f"LEFT JOIN #{column_name} ON #{column_name}.patient_id = #population.patient_id"


### PR DESCRIPTION
This prevents us from e.g. calculating the BMI of every patient in the
system only to throw most of these results away later because our study
population is only a small subset of all patients.

How much performance difference this will make depends on what fraction
of the patients in the database are in the study. At some sufficiently
high ratio it will presumably reduce performance as it introduces an
extra join for each covariate that doesn't end up removing many rows.

With only the dummy data to test against it's hard to know what's best
so I'll leave this PR here in case it's needed.