### PR TITLE
Support multiple study definitions

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -56,10 +56,11 @@ import delimited `c(pwd)'/analysis/input.csv
 
 At the moment, this involves writing some simple Python code.
 
-This must live in a file at `analysis/study_definition.py`.  Until
-more documentation is written, refer to the sample one provided here
-for inspiration; or, if you're feeling adventurous, search the tests
-(in `tests/`) for `StudyDefinition` examples.
+This must live in a file at `analysis/study_definition.py` (or
+`analysis/study_definition_<name>.py` if you have multiple studies).
+Until more documentation is written, refer to the sample one provided
+here for inspiration; or, if you're feeling adventurous, search the
+tests (in `tests/`) for `StudyDefinition` examples.
 
 ## Generating dummy data
 
@@ -76,7 +77,11 @@ password.  When running outside the secure environment, obtain a URL
 that gives you access to the publicly-available dummy dataset.
 
 Now double-click `run.exe`, and it will use your covariate definitions
-in `analysis/study_definition.py` to generate a data file at `analysis/input.csv`
+in `analysis/study_definition.py` to generate a data file at `analysis/input.csv`.
+
+If you have multiple study definitions named like
+`analysis/study_definition_<name>.py` then the corresponding output
+files will be named `analysis/input_<name>.csv`.
 
 You can now use Stata as you usually would, with your code entrypoint
 in `analysis/model.do`.

--- a/run.py
+++ b/run.py
@@ -4,6 +4,7 @@ shutdowns gracefully
 """
 import runner
 import glob
+import importlib
 import os
 import re
 import requests
@@ -250,10 +251,7 @@ def make_chart(name, series, dtype):
 
 def generate_cohort(expectations_population):
     print("Running. Please wait...")
-    _set_up_path()
-    # Avoid creating __pycache__ files in the analysis directory
-    sys.dont_write_bytecode = True
-    from study_definition import study
+    study = load_study_definition()
 
     with_sqlcmd = shutil.which("sqlcmd") is not None
     study.to_csv(
@@ -265,10 +263,7 @@ def generate_cohort(expectations_population):
 
 
 def make_cohort_report():
-    _set_up_path()
-    # Avoid creating __pycache__ files in the analysis directory
-    sys.dont_write_bytecode = True
-    from study_definition import study
+    study = load_study_definition()
 
     df = study.csv_to_df("analysis/input.csv")
     descriptives = df.describe(include="all")
@@ -367,21 +362,20 @@ def update_codelists():
 
 
 def dump_cohort_sql():
-    _set_up_path()
-    from study_definition import study
-
+    study = load_study_definition()
     print(study.to_sql())
 
 
 def dump_study_yaml():
-    _set_up_path()
-    from study_definition import study
-
+    study = load_study_definition()
     print(yaml.dump(study.to_data()))
 
 
-def _set_up_path():
+def load_study_definition():
     sys.path.extend([relative_dir(), os.path.join(relative_dir(), "analysis")])
+    # Avoid creating __pycache__ files in the analysis directory
+    sys.dont_write_bytecode = True
+    return importlib.import_module("study_definition").study
 
 
 def main(from_cmd_line=False):

--- a/run.py
+++ b/run.py
@@ -250,22 +250,32 @@ def make_chart(name, series, dtype):
 
 
 def generate_cohort(expectations_population):
+    for study_name, suffix in list_study_definitions():
+        _generate_cohort(study_name, suffix, expectations_population)
+
+
+def _generate_cohort(study_name, suffix, expectations_population):
     print("Running. Please wait...")
-    study = load_study_definition()
+    study = load_study_definition(study_name)
 
     with_sqlcmd = shutil.which("sqlcmd") is not None
     study.to_csv(
-        "analysis/input.csv",
+        f"analysis/input{suffix}.csv",
         expectations_population=expectations_population,
         with_sqlcmd=with_sqlcmd,
     )
-    print("Successfully created cohort and covariates at analysis/input.csv")
+    print(f"Successfully created cohort and covariates at analysis/input{suffix}.csv")
 
 
 def make_cohort_report():
-    study = load_study_definition()
+    for study_name, suffix in list_study_definitions():
+        _make_cohort_report(study_name, suffix)
 
-    df = study.csv_to_df("analysis/input.csv")
+
+def _make_cohort_report(study_name, suffix):
+    study = load_study_definition(study_name)
+
+    df = study.csv_to_df(f"analysis/input{suffix}.csv")
     descriptives = df.describe(include="all")
 
     for name, dtype in zip(df.columns, df.dtypes):
@@ -288,7 +298,7 @@ def make_cohort_report():
         descriptives.loc["values", name] = main_chart
         descriptives.loc["nulls", name] = empty_values_chart
 
-    with open("analysis/descriptives.html", "w") as f:
+    with open(f"analysis/descriptives{suffix}.html", "w") as f:
 
         f.write(
             """<html>
@@ -320,7 +330,7 @@ def make_cohort_report():
 
         f.write(descriptives.to_html(escape=False, na_rep="", justify="left", border=0))
         f.write("</body></html>")
-    print("Created cohort report at analysis/descriptives.html")
+    print(f"Created cohort report at analysis/descriptives{suffix}.html")
 
 
 def run_model(folder, stata_path=None):
@@ -362,20 +372,29 @@ def update_codelists():
 
 
 def dump_cohort_sql():
-    study = load_study_definition()
+    study = load_study_definition("study_definition")
     print(study.to_sql())
 
 
 def dump_study_yaml():
-    study = load_study_definition()
+    study = load_study_definition("study_definition")
     print(yaml.dump(study.to_data()))
 
 
-def load_study_definition():
+def load_study_definition(name):
     sys.path.extend([relative_dir(), os.path.join(relative_dir(), "analysis")])
     # Avoid creating __pycache__ files in the analysis directory
     sys.dont_write_bytecode = True
-    return importlib.import_module("study_definition").study
+    return importlib.import_module(name).study
+
+
+def list_study_definitions():
+    pattern = re.compile(r"^(study_definition(_\w+)?)\.py$")
+    for name in sorted(os.listdir(os.path.join(relative_dir(), "analysis"))):
+        if match := pattern.match(name):
+            name = match.group(1)
+            suffix = match.group(2) or ""
+            yield name, suffix
 
 
 def main(from_cmd_line=False):


### PR DESCRIPTION
Multiple study definition files can now be specified using a suffix like:
```
study_definition_bright_light.py
study_definition_iv_lysol.py
```

And all the corresponding output files will have the same suffix e.g.
```
input_bright_light.csv
input_iv_lysol.csv
descriptives_bright_light.html
descriptives_iv_lysol.html
```