### PR TITLE
Remove use of Python 3.8 walrus operator

### DIFF
--- a/run.py
+++ b/run.py
@@ -391,7 +391,8 @@ def load_study_definition(name):
 def list_study_definitions():
     pattern = re.compile(r"^(study_definition(_\w+)?)\.py$")
     for name in sorted(os.listdir(os.path.join(relative_dir(), "analysis"))):
-        if match := pattern.match(name):
+        match = pattern.match(name)
+        if match:
             name = match.group(1)
             suffix = match.group(2) or ""
             yield name, suffix


### PR DESCRIPTION
I thought this would be a fun occasion to try it out as we're
controlling the Python version within Docker. But of course `run.py` is
run _outside_ of Docker...